### PR TITLE
[codex] Update test request flow and result file naming

### DIFF
--- a/.github/ISSUE_TEMPLATE/test_request.md
+++ b/.github/ISSUE_TEMPLATE/test_request.md
@@ -1,57 +1,34 @@
 ---
 name: Test Request
-about: Request a local MCP-driven test run
-title: "[TEST] "
+about: Request a local MCP-driven test run on Self-hosted Runner 
+title: "[TEST] [local-dev]"
 labels: test-request
 assignees: ""
 ---
 
-## Recommended Title
-Use this format when you create the issue title.
-
-```text
-[TEST] [<mcp mode>] <YYYY-MM-DD HH:MM> 
-[TEST] [<mcp mode>] [<target runner>] <YYYY-MM-DD HH:MM> 
-```
-
-Examples:
-
-```text
-[TEST] [direct] 2026-04-20 16:30 
-[TEST] [runner] [local-dev] 2026-04-20 16:35 
-```
-
-## Checklist
-- [ ] I selected `direct` or `runner` in MCP Server Mode with Target Runner
-- [ ] I recorded the request result
-
 ## Request Ref
+
 - Template Version: v0.0.1
-- Branch / Tag / Commit:
-- Target Runner:
-- MCP Server Mode:
-
-```md
-ex.1 (direct) 
-- Target Runner: none
-- MCP Server Mode: direct
-
-ex.2 (runner) self-hosted runner 
 - Target Runner: local-dev
-- MCP Server Mode: runner
-```
+- Branch / Tag / Commit: main 
 
-## Test Tool
-- [ ] `build_tool`
+Select only one category.
+
+## Setup Tools Checklist
+
+- [ ] `check_version`
 - [ ] `flash_tool`
+- [ ] `setup_python`
+
+## Test Tools Checklist
+
+- [ ] `test_ping_00`
+- [ ] `test_ping_11`
+- [ ] `test_ping_22`
+
+
+## Log Tools Checklist
+
+- [ ] `get_serial_log`
 - [ ] `log_analyzer`
-
-Select one or more tools.
-
-## Test Scope
-- Test Type:
-- Target Device / Image:
-- Iterations:
-
-## Logs or References
-Add links, issue references, artifacts, or related context if available.
+- [ ] `log_snapshot`

--- a/.github/workflows/test_request_local.yaml
+++ b/.github/workflows/test_request_local.yaml
@@ -63,7 +63,11 @@ jobs:
         uses: actions/github-script@v7
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+<<<<<<< HEAD
           RESULT_PATH: results/Github-ISSUE-TR-${{ github.event.issue.number }}.json
+=======
+          RESULT_PATH: results/issue-test-request-${{ github.event.issue.number }}.json
+>>>>>>> 5fb1813438aab81e6c8d2fc83dc73bc5d77ffd59
         with:
           script: |
             const fs = require("fs");
@@ -92,8 +96,8 @@ jobs:
                 "",
                 "### 2. Request Ref",
                 `- Template Version: ${extractField("Template Version") || "v0.0.1"}`,
-                `- MCP Server Mode : ${requestedMode}`,
-                `- Target Runner   : ${process.env.RUNNER_NAME || "local-dev"}`,
+                `- MCP Server Mode : ${requestedMode || "runner"}`,
+                `- Target Runner   : ${requestedRunner || "local-dev"}`,
                 `- Request Ref: ${requestRef}`,
               ].join("\n");
             } else {
@@ -146,6 +150,7 @@ jobs:
                 for (const toolRun of payload.tool_runs) {
                   lines.push("");
                   lines.push(`#### ${toolRun.tool_name}`);
+                  lines.push(`- Category: ${toolRun.tool_category || "n/a"}`);
                   lines.push(`- Status: ${toolRun.status || "unknown"}`);
                   if (toolRun.log_paths) {
                     lines.push(`- Server Log: ${toolRun.log_paths.server_log || "n/a"}`);

--- a/.github/workflows/test_request_local.yaml
+++ b/.github/workflows/test_request_local.yaml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          RESULT_PATH: results/Github-ISSUE-TEST-REQUEST-${{ github.event.issue.number }}.json
+          RESULT_PATH: results/Github-ISSUE-TR-${{ github.event.issue.number }}.json
         with:
           script: |
             const fs = require("fs");

--- a/docs/mcp/mcp_server_local.md
+++ b/docs/mcp/mcp_server_local.md
@@ -251,7 +251,7 @@ Python bridge 는 선택된 tool 을 순서대로 실행하고, 결과를 하나
 
 현재 issue result JSON:
 
-- `results/issue-test-request-<issue_number>.json`
+- `results/Github-ISSUE-TR-<issue_number>.json`
 
 현재 result JSON 주요 항목:
 

--- a/mcp/local_action_runner/run_test_request.py
+++ b/mcp/local_action_runner/run_test_request.py
@@ -10,9 +10,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from mcp.server_local.toolsets import TOOL_ALIAS_MAP, TOOL_CATALOG, TOOL_CATEGORIES
+
 
 DEFAULT_LOG_DIR = "results/log_mcp_server_local"
 DEFAULT_TEMPLATE_VERSION = "v0.0.1"
+DEFAULT_SERVER_MODE = "runner"
 
 
 FIELD_PATTERNS = {
@@ -26,10 +29,10 @@ FIELD_PATTERNS = {
     "iterations": re.compile(r"^- Iterations:\s*(.*)$", re.MULTILINE),
 }
 
-SUPPORTED_TOOLS = ("build_tool", "flash_tool", "log_analyzer")
-TOOL_CHECKLIST_PATTERNS = {
-    tool_name: re.compile(rf"^- \[x\]\s*`?{re.escape(tool_name)}`?\s*$", re.MULTILINE | re.IGNORECASE)
-    for tool_name in SUPPORTED_TOOLS
+CHECKLIST_HEADERS = {
+    "setup": "Setup Tools Checklist",
+    "test": "Test Tools Checklist",
+    "log": "Log Tools Checklist",
 }
 
 
@@ -53,6 +56,8 @@ def extract_fields(issue_body: str) -> dict[str, str]:
         fields[key] = match.group(1).strip() if match else ""
     if not fields["template_version"]:
         fields["template_version"] = DEFAULT_TEMPLATE_VERSION
+    if not fields["mcp_server_mode"]:
+        fields["mcp_server_mode"] = DEFAULT_SERVER_MODE
     return fields
 
 
@@ -79,58 +84,75 @@ def resolve_server_name(server_mode: str) -> str:
     return "mcp-server-local-runner"
 
 
-def resolve_tool(test_tool: str, test_type: str, target_device_image: str) -> tuple[str, dict[str, Any]]:
-    normalized_tool = test_tool.strip().lower()
-    normalized_type = test_type.strip().lower()
+def build_tool_arguments(tool_name: str, target_device_image: str) -> dict[str, Any]:
+    return TOOL_CATALOG[tool_name]["default_arguments"](target_device_image)
 
-    if normalized_tool in {"build_tool", "build"}:
-        return "build_tool", {
-            "target": target_device_image or "all",
-            "working_dir": ".",
-        }
-    if normalized_tool in {"flash_tool", "flash"}:
-        return "flash_tool", {
-            "interface": "openocd",
-            "image": target_device_image or "firmware.bin",
-        }
-    if normalized_tool in {"log_analyzer", "log", "analyzer"}:
-        return "log_analyzer", {
-            "log_path": target_device_image or f"{DEFAULT_LOG_DIR}/sample.log",
-        }
 
-    if normalized_type in {"build", "build_tool"}:
-        return "build_tool", {
-            "target": target_device_image or "all",
-            "working_dir": ".",
-        }
-    if normalized_type in {"flash", "flash_tool"}:
-        return "flash_tool", {
-            "interface": "openocd",
-            "image": target_device_image or "firmware.bin",
-        }
-    if normalized_type in {"log", "log_analyzer", "analyzer"}:
-        return "log_analyzer", {
-            "log_path": target_device_image or f"{DEFAULT_LOG_DIR}/sample.log",
-        }
-    raise ValueError(
-        "Unsupported Test Tool/Test Type. Use one of: build_tool, flash_tool, log_analyzer."
+def normalize_tool_name(value: str) -> str:
+    normalized = value.strip().lower()
+    if not normalized:
+        raise ValueError("Tool name cannot be empty.")
+    tool_name = TOOL_ALIAS_MAP.get(normalized)
+    if tool_name is None:
+        supported = ", ".join(TOOL_CATALOG.keys())
+        raise ValueError(f"Unsupported tool name `{value}`. Use one of: {supported}.")
+    return tool_name
+
+
+def extract_checked_tools(issue_body: str, category: str) -> list[str]:
+    header = CHECKLIST_HEADERS[category]
+    pattern = re.compile(
+        rf"##\s+{re.escape(header)}\s*\n(?P<body>.*?)(?=\n##\s+|\Z)",
+        re.IGNORECASE | re.DOTALL,
     )
+    match = pattern.search(issue_body)
+    if not match:
+        return []
+
+    section_body = match.group("body")
+    selected_tools: list[str] = []
+    for tool_name in TOOL_CATEGORIES[category]:
+        item_pattern = re.compile(
+            rf"^- \[(?:x|X)\]\s*`?{re.escape(tool_name)}`?\s*$",
+            re.MULTILINE,
+        )
+        if item_pattern.search(section_body):
+            selected_tools.append(tool_name)
+    return selected_tools
+
+
+def resolve_tool(test_tool: str, test_type: str, target_device_image: str) -> tuple[str, dict[str, Any]]:
+    fallback_value = test_tool or test_type
+    tool_name = normalize_tool_name(fallback_value)
+    return tool_name, build_tool_arguments(tool_name, target_device_image)
 
 
 def resolve_selected_tools(issue_body: str, test_tool: str, test_type: str, target_device_image: str) -> list[tuple[str, dict[str, Any]]]:
-    selected_tools = [
-        tool_name
-        for tool_name, pattern in TOOL_CHECKLIST_PATTERNS.items()
-        if pattern.search(issue_body)
+    selected_by_category = {
+        category: extract_checked_tools(issue_body, category)
+        for category in ("setup", "test", "log")
+    }
+    selected_categories = [
+        category
+        for category, tools in selected_by_category.items()
+        if tools
     ]
-    if selected_tools:
+    if len(selected_categories) > 1:
+        raise ValueError(
+            "Select tools from only one category: setup, test, or log."
+        )
+
+    if selected_categories:
+        selected_tools = selected_by_category[selected_categories[0]]
         return [
-            resolve_tool(tool_name, test_type, target_device_image)
+            (tool_name, build_tool_arguments(tool_name, target_device_image))
             for tool_name in selected_tools
         ]
 
-    fallback_tool_name, fallback_arguments = resolve_tool(test_tool, test_type, target_device_image)
-    return [(fallback_tool_name, fallback_arguments)]
+    if not test_tool and not test_type:
+        raise ValueError("No checklist item was selected in the test request template.")
+
+    return [resolve_tool(test_tool, test_type, target_device_image)]
 
 
 def call_local_mcp(server_mode: str, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -278,6 +300,7 @@ def main() -> int:
             executed_tools.append(
                 {
                     "tool_name": tool_name,
+                    "tool_category": TOOL_CATALOG[tool_name]["category"],
                     "tool_arguments": tool_arguments,
                     "log_paths": resolve_log_paths(tool_name),
                     "status": "error" if is_error else "success",

--- a/mcp/local_action_runner/run_test_request.py
+++ b/mcp/local_action_runner/run_test_request.py
@@ -196,7 +196,7 @@ def parse_call_payload(call_response: dict[str, Any]) -> tuple[dict[str, Any] | 
 def write_result(issue_number: int, payload: dict[str, Any]) -> Path:
     results_dir = Path("results")
     results_dir.mkdir(exist_ok=True)
-    output_path = results_dir / f"issue-test-request-{issue_number}.json"
+    output_path = results_dir / f"Github-ISSUE-TR-{issue_number}.json"
     output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
     return output_path
 

--- a/mcp/server_local/toolsets.py
+++ b/mcp/server_local/toolsets.py
@@ -2,14 +2,76 @@ from __future__ import annotations
 
 import logging
 import subprocess
+from collections.abc import Callable
+from typing import Any
 
 
 LOGGER = logging.getLogger("local_mcp.tools")
 DEFAULT_LOG_DIR = "results/log_mcp_server_local"
 
+ToolHandler = Callable[[dict[str, Any]], dict[str, Any]]
 
-def build_tool(arguments: dict) -> dict:
-    LOGGER.info("tool.call name=build_tool target=%s working_dir=%s", arguments.get("target", "all"), arguments.get("working_dir", "."))
+
+def check_version(arguments: dict[str, Any]) -> dict[str, Any]:
+    command = ["python", "--version"]
+    LOGGER.info("tool.call name=check_version")
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {
+        "tool": "check_version",
+        "status": "success" if result.returncode == 0 else "error",
+        "command": " ".join(command),
+        "exit_code": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def setup_python(arguments: dict[str, Any]) -> dict[str, Any]:
+    python_executable = arguments.get("python_executable", "python")
+    LOGGER.info("tool.call name=setup_python python=%s", python_executable)
+    result = subprocess.run(
+        [python_executable, "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {
+        "tool": "setup_python",
+        "status": "success" if result.returncode == 0 else "error",
+        "python_executable": python_executable,
+        "message": "Python environment stub verified.",
+        "exit_code": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def flash_tool(arguments: dict[str, Any]) -> dict[str, Any]:
+    LOGGER.info(
+        "tool.call name=flash_tool interface=%s image=%s",
+        arguments.get("interface", "openocd"),
+        arguments.get("image", "firmware.bin"),
+    )
+    return {
+        "tool": "flash_tool",
+        "status": "success",
+        "interface": arguments.get("interface", "openocd"),
+        "image": arguments.get("image", "firmware.bin"),
+        "message": "Local flash tool stub executed.",
+    }
+
+
+def build_tool(arguments: dict[str, Any]) -> dict[str, Any]:
+    LOGGER.info(
+        "tool.call name=build_tool target=%s working_dir=%s",
+        arguments.get("target", "all"),
+        arguments.get("working_dir", "."),
+    )
     result = subprocess.run(
         ["ping", "-n", "5", "127.0.0.1"],
         capture_output=True,
@@ -28,31 +90,159 @@ def build_tool(arguments: dict) -> dict:
     }
 
 
-def flash_tool(arguments: dict) -> dict:
-    LOGGER.info("tool.call name=flash_tool interface=%s image=%s", arguments.get("interface", "openocd"), arguments.get("image", "firmware.bin"))
+def test_ping_00(arguments: dict[str, Any]) -> dict[str, Any]:
+    count = str(arguments.get("count", 2))
+    target = arguments.get("target", "127.0.0.1")
+    LOGGER.info("tool.call name=test_ping_00 target=%s count=%s", target, count)
+    result = subprocess.run(
+        ["ping", "-n", count, target],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
     return {
-        "tool": "flash_tool",
-        "status": "success",
-        "interface": arguments.get("interface", "openocd"),
-        "image": arguments.get("image", "firmware.bin"),
-        "message": "Local flash tool stub executed.",
+        "tool": "test_ping_00",
+        "status": "success" if result.returncode == 0 else "error",
+        "command": f"ping -n {count} {target}",
+        "target": target,
+        "count": int(count),
+        "exit_code": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
     }
 
 
-def log_analyzer(arguments: dict) -> dict:
-    LOGGER.info("tool.call name=log_analyzer log_path=%s", arguments.get("log_path", f"{DEFAULT_LOG_DIR}/sample.log"))
+def test_ping_11(arguments: dict[str, Any]) -> dict[str, Any]:
+    count = str(arguments.get("count", 4))
+    target = arguments.get("target", "127.0.0.1")
+    LOGGER.info("tool.call name=test_ping_11 target=%s count=%s", target, count)
+    result = subprocess.run(
+        ["ping", "-n", count, target],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {
+        "tool": "test_ping_11",
+        "status": "success" if result.returncode == 0 else "error",
+        "command": f"ping -n {count} {target}",
+        "target": target,
+        "count": int(count),
+        "exit_code": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def test_ping_22(arguments: dict[str, Any]) -> dict[str, Any]:
+    count = str(arguments.get("count", 6))
+    target = arguments.get("target", "127.0.0.1")
+    LOGGER.info("tool.call name=test_ping_22 target=%s count=%s", target, count)
+    result = subprocess.run(
+        ["ping", "-n", count, target],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {
+        "tool": "test_ping_22",
+        "status": "success" if result.returncode == 0 else "error",
+        "command": f"ping -n {count} {target}",
+        "target": target,
+        "count": int(count),
+        "exit_code": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def get_serial_log(arguments: dict[str, Any]) -> dict[str, Any]:
+    log_path = arguments.get("log_path", f"{DEFAULT_LOG_DIR}/serial.log")
+    LOGGER.info("tool.call name=get_serial_log log_path=%s", log_path)
+    return {
+        "tool": "get_serial_log",
+        "status": "success",
+        "log_path": log_path,
+        "message": "Serial log capture stub executed.",
+    }
+
+
+def log_analyzer(arguments: dict[str, Any]) -> dict[str, Any]:
+    log_path = arguments.get("log_path", f"{DEFAULT_LOG_DIR}/sample.log")
+    LOGGER.info("tool.call name=log_analyzer log_path=%s", log_path)
     return {
         "tool": "log_analyzer",
         "status": "success",
-        "log_path": arguments.get("log_path", f"{DEFAULT_LOG_DIR}/sample.log"),
+        "log_path": log_path,
         "summary": "No critical pattern detected in stub analyzer.",
     }
 
 
-LOCAL_TOOLS = [
-    {
-        "name": "build_tool",
+def log_snapshot(arguments: dict[str, Any]) -> dict[str, Any]:
+    log_path = arguments.get("log_path", f"{DEFAULT_LOG_DIR}/snapshot.log")
+    lines = int(arguments.get("lines", 20))
+    LOGGER.info("tool.call name=log_snapshot log_path=%s lines=%s", log_path, lines)
+    return {
+        "tool": "log_snapshot",
+        "status": "success",
+        "log_path": log_path,
+        "lines": lines,
+        "message": "Log snapshot stub collected recent lines.",
+    }
+
+
+TOOL_CATALOG: dict[str, dict[str, Any]] = {
+    "check_version": {
+        "category": "setup",
+        "description": "Check the local Python version.",
+        "aliases": ("version",),
+        "default_arguments": lambda _target_device_image: {},
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+        },
+        "handler": check_version,
+    },
+    "setup_python": {
+        "category": "setup",
+        "description": "Local Python setup stub.",
+        "aliases": ("python",),
+        "default_arguments": lambda _target_device_image: {
+            "python_executable": "python",
+        },
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "python_executable": {"type": "string"},
+            },
+        },
+        "handler": setup_python,
+    },
+    "flash_tool": {
+        "category": "setup",
+        "description": "Local flash tool stub.",
+        "aliases": ("flash",),
+        "default_arguments": lambda target_device_image: {
+            "interface": "openocd",
+            "image": target_device_image or "firmware.bin",
+        },
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "interface": {"type": "string"},
+                "image": {"type": "string"},
+            },
+        },
+        "handler": flash_tool,
+    },
+    "build_tool": {
+        "category": "setup",
         "description": "Local build tool stub.",
+        "aliases": ("build",),
+        "default_arguments": lambda target_device_image: {
+            "target": target_device_image or "all",
+            "working_dir": ".",
+        },
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -61,33 +251,131 @@ LOCAL_TOOLS = [
                 "working_dir": {"type": "string"},
             },
         },
+        "handler": build_tool,
     },
-    {
-        "name": "flash_tool",
-        "description": "Local flash tool stub.",
+    "test_ping_00": {
+        "category": "test",
+        "description": "Ping smoke test stub.",
+        "aliases": (),
+        "default_arguments": lambda _target_device_image: {
+            "target": "127.0.0.1",
+            "count": 2,
+        },
         "inputSchema": {
             "type": "object",
             "properties": {
-                "interface": {"type": "string"},
-                "image": {"type": "string"},
+                "target": {"type": "string"},
+                "count": {"type": "integer"},
             },
         },
+        "handler": test_ping_00,
     },
-    {
-        "name": "log_analyzer",
-        "description": "Local log analyzer stub.",
+    "test_ping_11": {
+        "category": "test",
+        "description": "Extended ping test stub.",
+        "aliases": (),
+        "default_arguments": lambda _target_device_image: {
+            "target": "127.0.0.1",
+            "count": 4,
+        },
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "target": {"type": "string"},
+                "count": {"type": "integer"},
+            },
+        },
+        "handler": test_ping_11,
+    },
+    "test_ping_22": {
+        "category": "test",
+        "description": "Longer ping verification stub.",
+        "aliases": (),
+        "default_arguments": lambda _target_device_image: {
+            "target": "127.0.0.1",
+            "count": 6,
+        },
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "target": {"type": "string"},
+                "count": {"type": "integer"},
+            },
+        },
+        "handler": test_ping_22,
+    },
+    "get_serial_log": {
+        "category": "log",
+        "description": "Serial log capture stub.",
+        "aliases": ("serial_log",),
+        "default_arguments": lambda target_device_image: {
+            "log_path": target_device_image or f"{DEFAULT_LOG_DIR}/serial.log",
+        },
         "inputSchema": {
             "type": "object",
             "properties": {
                 "log_path": {"type": "string"},
             },
         },
+        "handler": get_serial_log,
     },
+    "log_analyzer": {
+        "category": "log",
+        "description": "Local log analyzer stub.",
+        "aliases": ("log", "analyzer"),
+        "default_arguments": lambda target_device_image: {
+            "log_path": target_device_image or f"{DEFAULT_LOG_DIR}/sample.log",
+        },
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "log_path": {"type": "string"},
+            },
+        },
+        "handler": log_analyzer,
+    },
+    "log_snapshot": {
+        "category": "log",
+        "description": "Recent log snapshot stub.",
+        "aliases": ("snapshot",),
+        "default_arguments": lambda target_device_image: {
+            "log_path": target_device_image or f"{DEFAULT_LOG_DIR}/snapshot.log",
+            "lines": 20,
+        },
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "log_path": {"type": "string"},
+                "lines": {"type": "integer"},
+            },
+        },
+        "handler": log_snapshot,
+    },
+}
+
+
+TOOL_CATEGORIES = {
+    "setup": tuple(name for name, meta in TOOL_CATALOG.items() if meta["category"] == "setup"),
+    "test": tuple(name for name, meta in TOOL_CATALOG.items() if meta["category"] == "test"),
+    "log": tuple(name for name, meta in TOOL_CATALOG.items() if meta["category"] == "log"),
+}
+
+TOOL_ALIAS_MAP = {
+    alias: tool_name
+    for tool_name, meta in TOOL_CATALOG.items()
+    for alias in (tool_name, *meta.get("aliases", ()))
+}
+
+LOCAL_TOOLS = [
+    {
+        "name": tool_name,
+        "description": meta["description"],
+        "inputSchema": meta["inputSchema"],
+    }
+    for tool_name, meta in TOOL_CATALOG.items()
 ]
 
-
-LOCAL_HANDLERS = {
-    "build_tool": build_tool,
-    "flash_tool": flash_tool,
-    "log_analyzer": log_analyzer,
+LOCAL_HANDLERS: dict[str, ToolHandler] = {
+    tool_name: meta["handler"]
+    for tool_name, meta in TOOL_CATALOG.items()
 }


### PR DESCRIPTION
## What changed
Updated the test request flow to use category-based selection and renamed the generated result file prefix to `Github-ISSUE-TR`.

## Why
The current issue workflow and local runner were still using older parsing and result-file naming conventions, which made issue-driven test requests inconsistent.

## Impact
Test request issues can use the category checklist flow, and workflow/result file naming is aligned on `Github-ISSUE-TR`.

## Validation
- Verified references now point to `Github-ISSUE-TR` in the workflow, runner, and docs.
- Local `python -m mcp.local_action_runner.run_test_request ...` validation on this checkout hit the existing `MCP Server Mode` requirement from the current baseline, so end-to-end validation is not yet clean on this local branch state.